### PR TITLE
Initial support for .desktop applications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 
 all:
 	gcc `pkg-config --cflags gtk+-3.0 gtk-layer-shell-0` -o dicons dicons.c `pkg-config --libs gtk+-3.0 gtk-layer-shell-0`
+debug:
+	gcc -g `pkg-config --cflags gtk+-3.0 gtk-layer-shell-0` -o dicons dicons.c `pkg-config --libs gtk+-3.0 gtk-layer-shell-0`
 clangd:
 	bear -- gcc `pkg-config --cflags gtk+-3.0 gtk-layer-shell-0` -o dicons dicons.c `pkg-config --libs gtk+-3.0 gtk-layer-shell-0`
 install:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - [X] Start default application for the active file
 - [X] Update the Icons on changes to the directory (added/removed files)
 - [X] Drag and Drop Files from/to the Desktop
+- [X] Launching Apps from the Desktop
 - [ ] Multi-Monitor Support
 - [ ] Thumbnails for Images/Documents
 - [ ] Sort Rows of List Store based on Name/Type/Date

--- a/dicons.c
+++ b/dicons.c
@@ -171,6 +171,8 @@ static GtkListStore *create_desktop_list(void)
 static void launch_default_or_app_for_file(GFile *desktop_file) {
     GAppInfo *app;
     GKeyFile *keyfile = g_key_file_new ();
+    char* file_uri;
+
     if (g_key_file_load_from_file (keyfile, g_file_get_path(desktop_file), G_KEY_FILE_NONE, NULL))
     {
         app = (GAppInfo*)g_desktop_app_info_new_from_keyfile (keyfile);
@@ -182,7 +184,7 @@ static void launch_default_or_app_for_file(GFile *desktop_file) {
         }
     }
     // Not a .desktop, falling back to xdg open
-    char* file_uri = g_file_get_uri(desktop_file);
+    file_uri = g_file_get_uri(desktop_file);
     g_app_info_launch_default_for_uri(file_uri, 0, 0);
 }
 

--- a/dicons.c
+++ b/dicons.c
@@ -43,32 +43,29 @@ void append_row_from_file(GtkListStore *store, GFile *file)
 {
     GtkTreeIter iter;
     GFileInfo *file_info;
+    GdkPixbuf *pixbuf;
+    GAppInfo *app;
     const gchar *display_name = NULL;
-    GdkPixbuf *pixbuf = NULL;
+    GdkPixbuf *icon = NULL;
 
     GKeyFile *keyfile = g_key_file_new ();
     file_info = g_file_query_info(file, "standard::*,ownser::user", 0, 0, 0);
     if (g_key_file_load_from_file (keyfile, g_file_get_path(file), G_KEY_FILE_NONE, NULL))
     {
-        GAppInfo* app = (GAppInfo*)g_desktop_app_info_new_from_keyfile (keyfile);
-        if(app) {
+        app = (GAppInfo*)g_desktop_app_info_new_from_keyfile (keyfile);
+        if (app) {
             display_name = g_app_info_get_display_name(app);
-            pixbuf = gtk_icon_info_load_icon(
-                    gtk_icon_theme_lookup_by_gicon(
-                        theme,
-                        g_app_info_get_icon(app),
-                        48, 0), 0);
+            icon = g_app_info_get_icon(app);
         }
     }
 
-    if(!display_name)
+    if (!display_name)
         display_name = g_file_info_get_display_name(file_info);
-    if(!pixbuf)
-        pixbuf = gtk_icon_info_load_icon(
-                gtk_icon_theme_lookup_by_gicon(
-                    theme,
-                    g_file_info_get_icon(file_info),
-                    48, 0), 0);
+    if (!icon)
+        icon = g_file_info_get_icon(file_info);
+
+    pixbuf = gtk_icon_info_load_icon(
+            gtk_icon_theme_lookup_by_gicon(theme, icon, 48, 0), 0);
 
     gtk_list_store_append(store, &iter);
     gtk_list_store_set(store, &iter,
@@ -171,19 +168,20 @@ static GtkListStore *create_desktop_list(void)
     return GTK_LIST_STORE(store);
 }
 
-static void launch_desktop_shortcut(GFile *desktop_file) {
+static void launch_default_or_app_for_file(GFile *desktop_file) {
+    GAppInfo *app;
     GKeyFile *keyfile = g_key_file_new ();
     if (g_key_file_load_from_file (keyfile, g_file_get_path(desktop_file), G_KEY_FILE_NONE, NULL))
     {
-        GAppInfo* app = (GAppInfo*)g_desktop_app_info_new_from_keyfile (keyfile);
-        if(app) {
+        app = (GAppInfo*)g_desktop_app_info_new_from_keyfile (keyfile);
+        if (app) {
             GAppLaunchContext* app_context = g_app_launch_context_new ();
             g_app_info_launch(app, NULL, app_context, NULL);
             g_clear_object (&app_context);
             return;
         }
     }
-    // Not a .desktop, trying xdg open
+    // Not a .desktop, falling back to xdg open
     char* file_uri = g_file_get_uri(desktop_file);
     g_app_info_launch_default_for_uri(file_uri, 0, 0);
 }
@@ -199,7 +197,7 @@ static void activate_cb(GtkIconView *icon_view, GtkTreePath *tree_path, gpointer
 
     gtk_tree_model_get (GTK_TREE_MODEL (store), &iter, COL_FILE, &file, -1);
 
-    launch_desktop_shortcut(file);
+    launch_default_or_app_for_file(file);
 }
 
 static void activate (GtkApplication* app, gpointer user_data)

--- a/dicons.c
+++ b/dicons.c
@@ -46,7 +46,7 @@ void append_row_from_file(GtkListStore *store, GFile *file)
     GdkPixbuf *pixbuf;
     GAppInfo *app;
     const gchar *display_name = NULL;
-    GdkPixbuf *icon = NULL;
+    GIcon *icon = NULL;
 
     GKeyFile *keyfile = g_key_file_new ();
     file_info = g_file_query_info(file, "standard::*,ownser::user", 0, 0, 0);


### PR DESCRIPTION
![image](https://github.com/Geronymos/desktop-icons/assets/68742864/0b767661-6566-47f3-a49c-be73ae80a4f1)

Display proper icons and title and also launch .desktop applications instead of opening their files with default mime.